### PR TITLE
refactor: migrate faker to @faker-js/faker

### DIFF
--- a/match_seed.js
+++ b/match_seed.js
@@ -1,12 +1,13 @@
 // seed.js
 
 require('dotenv').config();
-const faker = require('faker');
+const { faker } = require('@faker-js/faker');
 const mongoose = require('mongoose');
 const Match = require('./models/match');
 
 // Connect to your MongoDB database
-mongoose.connect(process.env.MONGODB_URI, { useNewUrlParser: true, useUnifiedTopology: true })
+mongoose
+  .connect(process.env.MONGODB_URI, { useNewUrlParser: true, useUnifiedTopology: true })
   .then(() => {
     console.log('Connected to MongoDB');
     seedData();
@@ -18,19 +19,17 @@ mongoose.connect(process.env.MONGODB_URI, { useNewUrlParser: true, useUnifiedTop
 // Seed match data
 const seedData = async () => {
   try {
-    // Create an array to hold the generated matches
-    const matches = [];
-
     // Generate sample matches
-    for (let i = 0; i < 10; i++) {
-      const match = {
+    const matches = faker.helpers.multiple(
+      () => ({
         date: faker.date.past(),
-        player1: faker.name.firstName(),
-        player2: faker.name.firstName(),
-        winner: faker.random.arrayElement(['Player 1', 'Player 2']),
-      };
-      matches.push(match);
-    }
+        player1: faker.person.firstName(),
+        player2: faker.person.firstName(),
+        winner: faker.helpers.arrayElement(['Player 1', 'Player 2']),
+      }),
+      { count: 10 }
+    );
+
 
     // Insert matches into the database
     await Match.insertMany(matches);

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,24 @@
         "mongoose": "^7.1.1"
       },
       "devDependencies": {
-        "faker": "^5.5.3"
+        "@faker-js/faker": "^9.2.0"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-9.2.0.tgz",
+      "integrity": "sha512-ulqQu4KMr1/sTFIYvqSdegHT8NIkt66tFAkugGnHA+1WAfEn6hMzNR+svjXGFRVLnapxvej67Z/LwchFrnLBUg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=9.0.0"
       }
     },
     "node_modules/@types/node": {
@@ -283,12 +300,6 @@
       "engines": {
         "node": ">= 0.10.0"
       }
-    },
-    "node_modules/faker": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/faker/-/faker-5.5.3.tgz",
-      "integrity": "sha512-wLTv2a28wjUyWkbnX7u/ABZBkUkIF2fCd73V6P2oFqEGEktDfzWx4UxrSqtPRw0xPRAcjeAOIiJWqZm3pP4u3g==",
-      "dev": true
     },
     "node_modules/finalhandler": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
     "mongoose": "^7.1.1"
   },
   "devDependencies": {
-    "faker": "^5.5.3"
+    "@faker-js/faker": "^9.2.0"
   }
 }

--- a/player_seed.js
+++ b/player_seed.js
@@ -1,5 +1,5 @@
 const mongoose = require('mongoose');
-const faker = require('faker');
+const { faker } = require('@faker-js/faker');
 require('dotenv').config();
 
 const Player = require('./models/player');
@@ -19,15 +19,14 @@ db.once('open', async () => {
     await Player.deleteMany({});
 
     // Generate fake players and save them to the database
-    const players = [];
-    for (let i = 0; i < 10; i++) {
-      const player = new Player({
-        name: faker.name.findName(),
-        winLossRatio: faker.random.number({ min: 0, max: 1, precision: 0.01 }),
-        elo: faker.random.number({ min: 1000, max: 3000 }),
-      });
-      players.push(player);
-    }
+    const players = faker.helpers.multiple(
+      () => new Player({
+          name: faker.person.findName(),
+          winLossRatio: faker.number.float({ min: 0, max: 1, fractionDigits: 2 }),
+          elo: faker.number.int({ min: 1000, max: 3000 }),
+      }),
+      { count: 10 }
+    );
 
     await Player.insertMany(players);
     console.log('Database seeded successfully');

--- a/stats.js
+++ b/stats.js
@@ -1,4 +1,4 @@
-const faker = require('faker');
+const { faker } = require('@faker-js/faker');
 const mongoose = require('mongoose');
 const PlayerStats = require('./models/player');
 const Match = require('./models/match');
@@ -25,7 +25,7 @@ const generatePlayerStatsData = async () => {
       if (!playerStatsData.some((player) => player.name === player1)) {
         playerStatsData.push({
           name: player1,
-          elo: faker.random.number(2000), // Assign a random ELO score using Faker
+          elo: faker.number.int(2000), // Assign a random ELO score using Faker
         });
       }
 
@@ -33,7 +33,7 @@ const generatePlayerStatsData = async () => {
       if (!playerStatsData.some((player) => player.name === player2)) {
         playerStatsData.push({
           name: player2,
-          elo: faker.random.number(2000), // Assign a random ELO score using Faker
+          elo: faker.number.int(2000), // Assign a random ELO score using Faker
         });
       }
 


### PR DESCRIPTION
## Description

This PR replaces the old `faker` library with the new community-driven `@faker-js/faker` library. The original `faker` library, once a popular choice for generating fake data, became unmaintained in January 2022. In response, the community came together to create `@faker-js/faker`, ensuring continued support and improvements. You can read more about this on our [website](https://fakerjs.dev/about/announcements/2022-01-14.html#i-heard-something-happened-what-s-the-tldr).

For transparency, I want to mention that I'm one of the maintainers of the new library.

We are actively seeking projects that still use the old library. By migrating these projects, we aim to prevent developers from inadvertently using outdated libraries when searching for code examples.
